### PR TITLE
Code review for 6.1.1 global stylesheet invalidation testing plugin

### DIFF
--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -5,3 +5,14 @@
  * Version: 0.1
  */
 
+// Initialize plugin.
+WP_Test_56970_Controller::init();
+
+class WP_Test_56970_Controller {
+	public static function init() {
+		add_action( 'init', 'wp_test_56970_init' );
+	}
+}
+
+function wp_test_56970_init() {
+}

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Test for Trac 56970
- * Description: Clears global stylesheet transient. See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a>.
+ * Description: Clears the global stylesheet transient after upgrade to 6.1.1. See <a href="https://core.trac.wordpress.org/ticket/56970">Trac 56970</a>.
  * Version: 0.1
  */
 

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -25,6 +25,10 @@ class WP_Test_56970_Controller {
 function wp_test_56970_init() {
 	global $wp_version;
 
+	if ( ! get_option( 'wp_test_56970_run' ) ) {
+		return;
+	}
+
 	// Issue described in Trac 56970 only affects upgrade from 5.9/6.0 to 6.1.1.
 	if ( '6.1.1' === $wp_version ) {
 		// Name of `global_styles_` stylesheet transient, e.g. 'global_styles_twentytwentyone'.

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -21,5 +21,10 @@ function wp_test_56970_init() {
 	if ( '6.1.1' === $wp_version ) {
 		// Name of `global_styles_` stylesheet transient, e.g. 'global_styles_twentytwentyone'.
 		$transient_name = 'global_styles_' . get_stylesheet();
+		// Hook to invalidate the transient.
+		add_filter( "transient_$transient_name", 'wp_test_56970_transient_global_styles_stylesheet', 10, 2 );
 	}
+}
+
+function wp_test_56970_transient_global_styles_stylesheet( $value, $transient ) {
 }

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -15,4 +15,9 @@ class WP_Test_56970_Controller {
 }
 
 function wp_test_56970_init() {
+	global $wp_version;
+
+	// Issue described in Trac 56970 only affects upgrade from 5.9/6.0 to 6.1.1.
+	if ( '6.1.1' === $wp_version ) {
+	}
 }

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -39,5 +39,8 @@ function wp_test_56970_init() {
 }
 
 function wp_test_56970_transient_global_styles_stylesheet( $value, $transient ) {
+	// Prevent hook from firing again.
+	update_option( 'wp_test_56970_run', false );
+
 	return false;
 }

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -19,5 +19,7 @@ function wp_test_56970_init() {
 
 	// Issue described in Trac 56970 only affects upgrade from 5.9/6.0 to 6.1.1.
 	if ( '6.1.1' === $wp_version ) {
+		// Name of `global_styles_` stylesheet transient, e.g. 'global_styles_twentytwentyone'.
+		$transient_name = 'global_styles_' . get_stylesheet();
 	}
 }

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -11,6 +11,12 @@ WP_Test_56970_Controller::init();
 class WP_Test_56970_Controller {
 	public static function init() {
 		add_action( 'init', 'wp_test_56970_init' );
+		register_activation_hook( __FILE__, array( __CLASS__, 'activate' ) );
+		register_deactivation_hook( __FILE__, array( __CLASS__, 'deactivate' ) );
+	}
+	public static function activate() {
+	}
+	public static function deactivate() {
 	}
 }
 

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -16,9 +16,13 @@ class WP_Test_56970_Controller {
 	}
 	public static function activate() {
 		add_option( 'wp_test_56970_run', true );
+		register_uninstall_hook( __FILE__, array( __CLASS__, 'uninstall' ) );
 	}
 	public static function deactivate() {
 		delete_option( 'wp_test_56970_run' );
+	}
+	public static function uninstall() {
+		self::deactivate();
 	}
 }
 

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -15,8 +15,10 @@ class WP_Test_56970_Controller {
 		register_deactivation_hook( __FILE__, array( __CLASS__, 'deactivate' ) );
 	}
 	public static function activate() {
+		add_option( 'wp_test_56970_run', true );
 	}
 	public static function deactivate() {
+		delete_option( 'wp_test_56970_run' );
 	}
 }
 

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -27,4 +27,5 @@ function wp_test_56970_init() {
 }
 
 function wp_test_56970_transient_global_styles_stylesheet( $value, $transient ) {
+	return false;
 }


### PR DESCRIPTION
Creates a testing plugin to address issue described in [Trac 56970](https://core.trac.wordpress.org/ticket/56970).

## Why a testing plugin?
Because the issue occurs after upgrade from WordPress 5.9/6.0 to 6.1.1 specifically, is hard to reproduce. Making a plugin available to the community allows for easier testing to validate whether this approach is works. If this plugin is found to address the reported issue, then the implementation may be adapted in an upcoming minor release.

## Details
- Runs under WordPress 6.1.1.
- Hooks the `transient_$transient_name` filter to invalidate the cache for `'global_styles_<stylesheet>'.
- Only runs the hook once. This is sufficient to force regeneration of the global stylesheet, which is subsequently cached.

Note that this is a different approach from that proposed [in wp-hotfix-56970/pull/1](https://github.com/ironprogrammer/wp-hotfix-56970/pull/1). While the other plugin *does* resolve the issue in local controlled testing, it also introduces caching changes from Gutenberg to Core that should ideally ship with the next major *after* the code has had more time to bake in Gutenberg. 43%.

## Testing
Tested with 5.9 and 6.0, and addresses issue described per the [testing instructions](https://core.trac.wordpress.org/ticket/56970#comment:42).

More testing is needed by the community in different hosting environments, to determine whether it works when external caching is at play.
