### PR TITLE
Add core update hook to clear global styles stylesheet

### DIFF
--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -48,3 +48,16 @@ function wp_test_56970_transient_global_styles_stylesheet( $value, $transient ) 
 
 	return false;
 }
+
+add_action( '_core_updated_successfully', '_delete_global_styles_stylesheet_transient' );
+if ( ! function_exists( '_delete_global_styles_stylesheet_transient' ) ) {
+	/**
+	 * Deletes the global styles stylesheet transient.
+	 *
+	 * @since 6.1.2
+	 */
+	function _delete_global_styles_stylesheet_transient() {
+		$transient_name = 'global_styles_' . get_stylesheet();
+		delete_site_transient( "transient_{$transient_name}" );
+	}
+}

--- a/wp-test-56970.php
+++ b/wp-test-56970.php
@@ -49,15 +49,9 @@ function wp_test_56970_transient_global_styles_stylesheet( $value, $transient ) 
 	return false;
 }
 
-add_action( '_core_updated_successfully', '_delete_global_styles_stylesheet_transient' );
-if ( ! function_exists( '_delete_global_styles_stylesheet_transient' ) ) {
-	/**
-	 * Deletes the global styles stylesheet transient.
-	 *
-	 * @since 6.1.2
-	 */
-	function _delete_global_styles_stylesheet_transient() {
-		$transient_name = 'global_styles_' . get_stylesheet();
-		delete_site_transient( "transient_{$transient_name}" );
-	}
+// Hook to delete the global styles stylesheet transient after core update.
+add_action( '_core_updated_successfully', 'wp_test_56970_delete_global_styles_stylesheet_transient' );
+function wp_test_56970_delete_global_styles_stylesheet_transient() {
+	$transient_name = 'global_styles_' . get_stylesheet();
+	delete_site_transient( "transient_{$transient_name}" );
 }


### PR DESCRIPTION
Adds function to delete the global styles stylesheet transient on core update.

- Guards against existing function to be proposed for 6.1.2.
- Clears this transient after ALL core upgrades, mitigating stale inline CSS behind reports in [Trac 56970](https://core.trac.wordpress.org/ticket/56970).
- Retains existing "run once" transient reset logic (hotfix) that still needs testing by the community. This is used if a site has already been updated to 6.1.1 and exhibits the issue described in the ticket.

Tested on upgrades from 5.9.5/6.0.3 to 6.1.1.
